### PR TITLE
fix: resolve layer linetype from DWG handle reference

### DIFF
--- a/bindings/javascript/src/converter/converter.ts
+++ b/bindings/javascript/src/converter/converter.ts
@@ -179,14 +179,16 @@ export class LibreDwgConverter {
     }
 
     // Process viewport entities: sort by objectId (handle) and assign viewportId
-    const viewportEntities = db.entities.filter(entity => entity.type === 'VIEWPORT') as DwgViewportEntity[]
+    const viewportEntities = db.entities.filter(
+      entity => entity.type === 'VIEWPORT'
+    ) as DwgViewportEntity[]
     viewportEntities.sort((a, b) => {
       // Convert handle to hex number for sorting
       const handleA = parseInt(a.handle, 16)
       const handleB = parseInt(b.handle, 16)
       return handleA - handleB
     })
-    
+
     // Assign viewportId starting from 1
     viewportEntities.forEach((viewport, index) => {
       viewport.viewportId = index + 1
@@ -645,6 +647,16 @@ export class LibreDwgConverter {
       .data as number
     const color = libredwg.dwg_dynapi_entity_value(item, 'color')
       .data as Dwg_Color
+    const ltypeRef = libredwg.dwg_dynapi_entity_value(item, 'ltype')
+      .data as number
+    let ltypeName = 'Continuous'
+    if (ltypeRef) {
+      try {
+        ltypeName = libredwg.dwg_ref_get_object_name(ltypeRef)
+      } catch {
+        // ref may be invalid in some DWG files
+      }
+    }
 
     // - 0xc0 for ByLayer (also c3 and rgb of 0x100)
     // - 0xc1 for ByBlock (also c3 and rgb of 0)
@@ -672,7 +684,7 @@ export class LibreDwgConverter {
       color: rgbColor,
       colorName: color.name,
       transparency: color.alpha,
-      lineType: '',
+      lineType: ltypeName,
       frozen: frozen != 0,
       off: off != 0,
       frozenInNew: frozenInNew != 0,

--- a/bindings/javascript/src/converter/entityConverter.ts
+++ b/bindings/javascript/src/converter/entityConverter.ts
@@ -139,10 +139,10 @@ export class LibreEntityConverter {
         return this.convertArc(entity_tio, commonAttrs)
       } else if (fixedtype == Dwg_Object_Type.DWG_TYPE_ATTDEF) {
         return this.convertAttdef(entity_tio, commonAttrs)
-      // libredwg stores ATTRIB as children of one INSERT entity.
-      // It does not exist in iterator of dwg data.
-      // } else if (fixedtype == Dwg_Object_Type.DWG_TYPE_ATTRIB) {
-      //   return this.convertAttrib(entity_tio, commonAttrs)
+        // libredwg stores ATTRIB as children of one INSERT entity.
+        // It does not exist in iterator of dwg data.
+        // } else if (fixedtype == Dwg_Object_Type.DWG_TYPE_ATTRIB) {
+        //   return this.convertAttrib(entity_tio, commonAttrs)
       } else if (fixedtype == Dwg_Object_Type.DWG_TYPE_CIRCLE) {
         return this.convertCircle(entity_tio, commonAttrs)
       } else if (


### PR DESCRIPTION
## Summary                                                                                                                                           
  - `convertLayer()` hardcoded `lineType: ''` for all layers, causing entities with `ByLayer` linetype to always render as continuous (solid) lines.   
  - Now reads the `ltype` handle reference from the LAYER object and resolves it to the linetype name via `dwg_ref_get_object_name()`.                 
  - Follows the same handle→name resolution pattern used for dimstyle and text style.                                                                  
                                                                                                                                                       
  Partial fix for mlightcad/cad-viewer#183.                                                                                                            
                                                                                                                                                       
  ## Test plan                                                                                                                                         
  - [x] Open `arquivo-test-defpoints.dwg` (AC1015/R_2000 architectural DWG)                                                                            
  - [x] Verify dashed/dotted lines on layers like `ARQ_PROJEÇÃO` now render with correct linetype pattern                                              
  - [x] Verify entities with explicit (non-ByLayer) linetypes still render correctly