### PR TITLE
Tolerate polylines without vertex arrays

### DIFF
--- a/bindings/javascript/src/converter/entityConverter.ts
+++ b/bindings/javascript/src/converter/entityConverter.ts
@@ -1814,7 +1814,8 @@ export class LibreEntityConverter {
     const thickness = libredwg.dwg_dynapi_entity_data<number>(entity, 'thickness')
     const extrusionDirection = libredwg.dwg_dynapi_entity_data<DwgPoint3D>(entity, 'extrusion')
 
-    const vertices = libredwg.dwg_entity_polyline_2d_get_vertices(object)
+    const vertices =
+      libredwg.dwg_entity_polyline_2d_get_vertices(object) ?? []
     return {
       type: 'POLYLINE2D',
       ...commonAttrs,
@@ -1856,7 +1857,8 @@ export class LibreEntityConverter {
     const endWidth = libredwg.dwg_dynapi_entity_data<number>(entity, 'end_width')
     const extrusionDirection = libredwg.dwg_dynapi_entity_data<DwgPoint3D>(entity, 'extrusion')
 
-    const vertices = libredwg.dwg_entity_polyline_3d_get_vertices(object)
+    const vertices =
+      libredwg.dwg_entity_polyline_3d_get_vertices(object) ?? []
     return {
       type: 'POLYLINE3D',
       ...commonAttrs,


### PR DESCRIPTION
# Tolerate polylines without vertex arrays

## Summary

- Treat missing 2D/3D polyline vertex arrays as empty arrays.
- Prevent a malformed polyline from aborting conversion of the whole DWG.

## Reproduction

An AC1015 drawing contains a `POLYLINE_2D` for which
`dwg_entity_polyline_2d_get_vertices()` returns `undefined`.

Before this change, `LibreEntityConverter.convertPolyline2d()` throws:

```text
TypeError: Cannot read properties of undefined (reading 'map')
```

The original customer drawing is confidential and is intentionally not attached.
With this change, the same drawing converts successfully with 736 entities and
0 unknown entities.

## Validation

```text
pnpm build  passed
pnpm lint   passed
pnpm test   passed (2/2)
```

The same guard is applied to `POLYLINE_3D`, which uses the same nullable WASM
return pattern.
